### PR TITLE
Replace Tigerbook image and description

### DIFF
--- a/index.html
+++ b/index.html
@@ -673,7 +673,7 @@
                     <div class="divider-custom-line"></div>
                 </div>
                 <div class="row justify-content-center">
-                    <!-- TigerBook-->
+                    <!-- Tigerbook-->
                     <div class="col-lg-4 mb-5">
                         <a href="http://tigerbook.herokuapp.com/" target="_blank">
                             <div class="portfolio-item mx-auto shadow mb-4 bg-body rounded">
@@ -707,14 +707,13 @@
                                     href="https://tigerbook.herokuapp.com/"
                                     target="_blank"
                                     class="no-underline"
-                                    >TigerBook</a
+                                    >Tigerbook</a
                                 >
                             </p>
                             <p class="fs-6 text-center fst-italic text-secondary mb-0">
-                                A unified directory of Princeton undergraduates. By Hansen Qian '16,
-                                Ivo Crnkovic-Rubsamen '15, Rohan Sharma '14, and Adam Libresco '19.
+                                A directory of Princeton undergraduate students.
                                 <br />
-                                Note: TigerBook is not managed by TigerApps.
+                                Note: Tigerbook has been retired in favor of the official Princeton directory.
                             </p>
                         </a>
                     </div>
@@ -1107,7 +1106,7 @@
                             Ayo Oguntola '23
                         </p>
                         <p class="fs-6 text-center fst-italic text-secondary mb-0">
-                            TigerBook Maintainer
+                            Tigerbook Maintainer
                         </p>
                     </div>
                     <!-- Emre -->

--- a/index.html
+++ b/index.html
@@ -713,7 +713,7 @@
                             <p class="fs-6 text-center fst-italic text-secondary mb-0">
                                 A directory of Princeton undergraduate students.
                                 <br />
-                                Note: Tigerbook has been retired in favor of the official Princeton directory.
+                                Note: The original student-built Tigerbook has been retired in favor of the Registrar's official Princeton directory.
                             </p>
                         </a>
                     </div>

--- a/index.html
+++ b/index.html
@@ -707,7 +707,7 @@
                                     href="https://tigerbook.herokuapp.com/"
                                     target="_blank"
                                     class="no-underline"
-                                    >Tigerbook</a
+                                    >Student Facebook</a
                                 >
                             </p>
                             <p class="fs-6 text-center fst-italic text-secondary mb-0">


### PR DESCRIPTION
Tigerbook's URL https://tigerbook.herokuapp.com/ now redirects to https://collface.deptcpanel.princeton.edu/, Princeton's official student directory.

![Google Chrome 08-26-2022 at 11 21 07 AM@2x](https://user-images.githubusercontent.com/13815069/186831608-2201e920-efad-4227-8a2b-6003ad1edd83.png)
